### PR TITLE
Prevent provider from touching commented lines with matching variable names

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -23,7 +23,8 @@ action :save do
   ruby_block "add rule" do
     block do
       sysfsFile = Chef::Util::FileEdit.new('/etc/sysfs.conf')
-      sysfsFile.insert_line_if_no_match(/#{getVariable}/, getVariable + ' = ' + new_resource.value)
+      sysfsFile.search_file_replace_line(/^\s*#{getVariable}/, getVariable + ' = ' + new_resource.value)
+      sysfsFile.insert_line_if_no_match(/^#{getVariable}/, getVariable + ' = ' + new_resource.value)
       sysfsFile.write_file
     end
   end
@@ -46,7 +47,7 @@ action :remove do
   ruby_block "add rule" do
     block do
       sysfsFile = Chef::Util::FileEdit.new('/etc/sysfs.conf')
-      sysfsFile.search_file_delete_line(/#{getVariable}/)
+      sysfsFile.search_file_delete_line(/^\s*#{getVariable}/)
       sysfsFile.write_file
     end
   end


### PR DESCRIPTION
Here is a beginning of the default sysfs.conf from debian:

```
#
# /etc/sysfs.conf - Configuration file for setting sysfs attributes.
#
# The sysfs mount directory is automatically prepended to the attribute paths.
#
# Syntax:
# attribute = value
# mode attribute = 0600 # (any valid argument for chmod)
# owner attribute = root:wheel # (any valid argument for chown)
#
# Examples:
#
# Always use the powersave CPU frequency governor
# devices/system/cpu/cpu0/cpufreq/scaling_governor = powersave
#
# Use userspace CPU frequency governor and set initial speed
# devices/system/cpu/cpu0/cpufreq/scaling_governor = userspace
# devices/system/cpu/cpu0/cpufreq/scaling_setspeed = 600000
```

If you try to save the variable 'devices/system/cpu/cpu0/cpufreq/scaling_governor' using sysfs resource, it's not going to happen because insert_line_if_no_match method will actually match the comment. Same problem with search_file_delete_line method.

I have changed a file patching logic a little and it worked for me. Hope it's useful.
